### PR TITLE
Fix incorrect function call

### DIFF
--- a/InnerClass.gd
+++ b/InnerClass.gd
@@ -4,7 +4,7 @@ extends Node
 var object = InnerClass.new()
 
 func _ready():
-	var getInnerValue = object.getA()
+	var getInnerValue = object.getAnother()
 	print(getInnerValue)
 
 class InnerClass:


### PR DESCRIPTION
`InnerClass` does not have a function called `getA` but `getAnother`.

In addition to that, I'd propose to replace the `extends Node` line in each `.gd` script and replace it with:
```
tool
extends EditorScript

func _run():
	_ready()
```

This allows executing the script within the Godot editor with `File -> Run` and see the effects of each class example first hand.